### PR TITLE
fix: 修复 pnpm 安装 @wangeditor/editor 出现警告的问题

### DIFF
--- a/packages/basic-modules/package.json
+++ b/packages/basic-modules/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-team/wangEditor-v5/issues"
   },
   "peerDependencies": {
-    "@wangeditor/core": "^0.7.1",
+    "@wangeditor/core": "0.x",
     "dom7": "^3.0.0",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^3.2.0",

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-team/wangEditor-v5/issues"
   },
   "peerDependencies": {
-    "@wangeditor/core": "^0.7.1",
+    "@wangeditor/core": "0.x",
     "dom7": "^3.0.0",
     "slate": "^0.72.0",
     "snabbdom": "^3.1.0"

--- a/packages/list-module/package.json
+++ b/packages/list-module/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-team/wangEditor-v5/issues"
   },
   "peerDependencies": {
-    "@wangeditor/core": "^0.7.1",
+    "@wangeditor/core": "0.x",
     "dom7": "^3.0.0",
     "slate": "^0.72.0",
     "snabbdom": "^3.1.0"

--- a/packages/table-module/package.json
+++ b/packages/table-module/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-team/wangEditor-v5/issues"
   },
   "peerDependencies": {
-    "@wangeditor/core": "^0.7.1",
+    "@wangeditor/core": "0.x",
     "dom7": "^3.0.0",
     "lodash.isequal": "^4.5.0",
     "nanoid": "^3.2.0",

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -43,8 +43,8 @@
   "peerDependencies": {
     "@uppy/core": "^2.0.3",
     "@uppy/xhr-upload": "^2.0.3",
-    "@wangeditor/basic-modules": "^0.9.0",
-    "@wangeditor/core": "^0.7.1",
+    "@wangeditor/basic-modules": "0.x",
+    "@wangeditor/core": "0.x",
     "dom7": "^3.0.0",
     "lodash.foreach": "^4.5.0",
     "slate": "^0.72.0",

--- a/packages/video-module/package.json
+++ b/packages/video-module/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@uppy/core": "^2.1.4",
     "@uppy/xhr-upload": "^2.0.7",
-    "@wangeditor/core": "^0.7.1",
+    "@wangeditor/core": "0.x",
     "dom7": "^3.0.0",
     "nanoid": "^3.2.0",
     "slate": "^0.72.0",


### PR DESCRIPTION
关联 [issue](https://github.com/wangeditor-team/wangEditor/issues/3907)。

解决思路：通过指定 @wangeditor/core 的 peerDependencies 的版本为 `0.x`，表示所有的 0.x.x 的版本都可用，只要没有 `break change` 版本。

reference: [npm peerdependencies](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies)。